### PR TITLE
Add license attribute in gemspec for v2.x

### DIFF
--- a/http-accept.gemspec
+++ b/http-accept.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
 
 	spec.summary       = %q{Parse Accept and Accept-Language HTTP headers.}
 	spec.homepage      = "https://github.com/ioquatix/http-accept"
+	spec.license       = 'MIT'
 
 	spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 	spec.bindir        = "exe"


### PR DESCRIPTION
This PR addresses https://github.com/socketry/http-accept/issues/8 for the 2.x version branch.

It add an explicit license attribute in the gemspec-file.